### PR TITLE
Sanity check issue

### DIFF
--- a/inc/ActionModel.h
+++ b/inc/ActionModel.h
@@ -46,5 +46,6 @@ protected:
 
 private:
     float _agent_size;
+    float _overlap_eps = 1e-4f;
     vector<char> _wait_agents;
 };

--- a/src/ActionModel.cpp
+++ b/src/ActionModel.cpp
@@ -597,7 +597,10 @@ void ActionModelWithRotate::sanity_check_states(const vector<State>& states)
                 obstacle.min_y = static_cast<float>(rr);
                 obstacle.max_x = obstacle.min_x + 1.0f;
                 obstacle.max_y = obstacle.min_y + 1.0f;
-                if (rects_overlap(r, obstacle))
+                const bool obs_overlap =
+                    r.min_x < obstacle.max_x - _overlap_eps && r.max_x > obstacle.min_x + _overlap_eps &&
+                    r.min_y < obstacle.max_y - _overlap_eps && r.max_y > obstacle.min_y + _overlap_eps;
+                if (obs_overlap)
                 {
                     throw std::runtime_error(
                         "Sanity check failed: agent " + std::to_string(i) + " overlaps hard obstacle");
@@ -646,7 +649,14 @@ void ActionModelWithRotate::sanity_check_states(const vector<State>& states)
                 rj.min_y = real[j].y;
                 rj.max_x = real[j].x + _agent_size;
                 rj.max_y = real[j].y + _agent_size;
-                if (rects_overlap(ri, rj))
+
+                // Epsilon tolerance consistent with moving_boxes_collide:
+                // agents whose boxes merely touch (overlap <= eps) are not
+                // in conflict — avoids false positives from float rounding.
+                const bool overlap =
+                    ri.min_x < rj.max_x - _overlap_eps && ri.max_x > rj.min_x + _overlap_eps &&
+                    ri.min_y < rj.max_y - _overlap_eps && ri.max_y > rj.min_y + _overlap_eps;
+                if (overlap)
                 {
                     throw std::runtime_error(
                         "Sanity check failed after dependency resolution: agent " + std::to_string(i) +

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -57,7 +57,7 @@ void validate_staged_actions_prefix(
 
     for (size_t agent = 0; agent < previous_staged_actions.size(); agent++)
     {
-        std::vector<Action> expected = previous_staged_actions[agent];
+        std::vector<Action> expected = normalize_plan_actions(previous_staged_actions[agent]);
         std::vector<Action> normalized = normalize_plan_actions(planned_actions[agent]);
         expected.insert(expected.end(), normalized.begin(), normalized.end());
 


### PR DESCRIPTION
Two things:
1. previous staged actions may also contain waits, thus need to remove these waits before validate_staged_actions_prefix. This has been fix in this pr.

2. after the fix, we get another error, which shows agents somehow overlaps, we need to figure out why:

when test with:
```
./build/lifelong --plannerPython true --schedulerPython true --executorPython true -i example_problems/random.domain/random-example_400.json -s 1000 -t 100 --output test 
```
we get:
```
libc++abi: terminating due to uncaught exception of type std::runtime_error: Sanity check failed after dependency resolution: agent 117 overlaps agent 167
[1]    79730 abort      ./build/lifelong --plannerPython true --schedulerPython true --executorPython
```